### PR TITLE
Fixed error "Undefined variable $attribute" when changing email

### DIFF
--- a/app/Http/Controllers/InfoUserController.php
+++ b/app/Http/Controllers/InfoUserController.php
@@ -45,7 +45,7 @@ class InfoUserController extends Controller
         User::where('id',Auth::user()->id)
         ->update([
             'name'    => $attributes['name'],
-            'email' => $attribute['email'],
+            'email' => $attributes['email'],
             'phone'     => $attributes['phone'],
             'location' => $attributes['location'],
             'about_me'    => $attributes["about_me"],


### PR DESCRIPTION
# Fixed spelling in variable
### Fixed error "Undefined variable $attribute" when changing email on the user-profile page.

## How to reproduce

Navigate to xyz.local/user-profile and change the email address in the form. This will throw an "Undefined variable $attribute" error exception.

## Fix

Changing "$attribute" to "$attributes" in [app/Http/Controllers/InfoUserController.php](https://github.com/creativetimofficial/soft-ui-dashboard-laravel/blob/master/app/Http/Controllers/InfoUserController.php#L50) fixes this issue.